### PR TITLE
Fix model classifier architecture to match trained weights, update gi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Data & models (too large for GitHub)
+data/raw/
+data/processed/
+data/food-101/
+*.pth
+*.pt
+*.h5
+
+# Kaggle credentials
+kaggle.json
+.kaggle/
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.env
+venv/
+.venv/
+
+# Jupyter
+.ipynb_checkpoints/
+*.ipynb_checkpoints
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Training outputs (generated files)
+training_curves.png
+confusion_matrix.png
+sample_images.png
+class_distribution.png
+calorie_distribution.png
+macronutrient_distribution.png
+
+# VSCode
+.vscode/

--- a/src/model.py
+++ b/src/model.py
@@ -10,5 +10,8 @@ def create_efficientnet_b0(num_classes: int = 101, pretrained: bool = False) -> 
     model = models.efficientnet_b0(weights=weights)
 
     in_features = model.classifier[1].in_features
-    model.classifier[1] = nn.Linear(in_features, num_classes)
+    model.classifier = nn.Sequential(
+    nn.Dropout(p=0.3, inplace=True),
+    nn.Linear(in_features, num_classes),
+)
     return model


### PR DESCRIPTION
## Summary
Fixed classifier architecture mismatch between src/model.py and the 
trained model weights in models/best_model.pth. Also updated .gitignore 
with missing entries.

## Related Issue
Closes #9

## Changes Made
- [x] src/model.py — updated create_efficientnet_b0() classifier from 
      nn.Linear only to nn.Sequential(Dropout + Linear) to match 
      training notebook architecture
- [x] .gitignore — added data/food-101/, training output images, 
      .vscode/, and *.ipynb_checkpoints

## Testing
- [x] Ran load test locally:
      model.load_state_dict(torch.load('models/best_model.pth'), strict=True)
      Result: OK — weights loaded successfully

## Notes
The mismatch was caused by model.py and model_training.ipynb using 
different classifier architectures. This fix ensures predict.py can 
load the trained weights without errors.